### PR TITLE
Import ExceptionMapper

### DIFF
--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -5,7 +5,6 @@
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  */
-
 package org.opendaylight.yangtools.util.concurrent;
 
 import static java.util.Objects.requireNonNull;
@@ -65,7 +64,7 @@ public abstract class ExceptionMapper<X extends Exception> implements Function<E
     protected abstract X newWithCause(String message, Throwable cause);
 
     @Override
-    @SuppressFBWarnings({"BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE"})
+    @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
     public X apply(final Exception input) {
 
         // If exception is of the specified type,return it.

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -8,8 +8,9 @@
 
 package org.opendaylight.yangtools.util.concurrent;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.base.Function;
-import com.google.common.base.Preconditions;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
@@ -47,8 +48,8 @@ public abstract class ExceptionMapper<X extends Exception> implements Function<E
      * @param exceptionType the exception type to which to translate.
      */
     public ExceptionMapper(final String opName, final Class<X> exceptionType) {
-        this.exceptionType = Preconditions.checkNotNull(exceptionType);
-        this.opName = Preconditions.checkNotNull(opName);
+        this.exceptionType = requireNonNull(exceptionType);
+        this.opName = requireNonNull(opName);
     }
 
     /**

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -81,22 +81,21 @@ public abstract class ExceptionMapper<X extends Exception> implements Function<E
         // If exception is ExecutionException whose cause is of the specified
         // type, return the cause.
         if (e instanceof ExecutionException && e.getCause() != null) {
-            if (exceptionType.isAssignableFrom( e.getCause().getClass())) {
+            if (exceptionType.isAssignableFrom(e.getCause().getClass())) {
                 return (X) e.getCause();
-            } else {
-                return newWithCause(opName + " execution failed", e.getCause());
             }
+            return newWithCause(opName + " execution failed", e.getCause());
         }
 
         // Otherwise return an instance of the specified type with the original
         // cause.
 
         if (e instanceof InterruptedException) {
-            return newWithCause( opName + " was interupted.", e);
+            return newWithCause(opName + " was interupted.", e);
         }
 
         if (e instanceof CancellationException ) {
-            return newWithCause( opName + " was cancelled.", e);
+            return newWithCause(opName + " was cancelled.", e);
         }
 
         // We really shouldn't get here but need to cover it anyway for completeness.

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -65,22 +65,23 @@ public abstract class ExceptionMapper<X extends Exception> implements Function<E
     protected abstract X newWithCause(String message, Throwable cause);
 
     @Override
-    @SuppressWarnings("unchecked")
     @SuppressFBWarnings({"BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE"})
     public X apply(final Exception input) {
 
         // If exception is of the specified type,return it.
-        if (exceptionType.isAssignableFrom(input.getClass())) {
-            return (X) input;
+        if (exceptionType.isInstance(input)) {
+            return exceptionType.cast(input);
         }
 
         // If exception is ExecutionException whose cause is of the specified
         // type, return the cause.
-        if (input instanceof ExecutionException && input.getCause() != null) {
-            if (exceptionType.isAssignableFrom(input.getCause().getClass())) {
-                return (X) input.getCause();
+        if (input instanceof ExecutionException) {
+            final var cause = input.getCause();
+            if (exceptionType.isInstance(cause)) {
+                return exceptionType.cast(cause);
+            } else if (cause != null) {
+                return newWithCause(opName + " execution failed", cause);
             }
-            return newWithCause(opName + " execution failed", input.getCause());
         }
 
         // Otherwise return an instance of the specified type with the original

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -17,20 +17,12 @@ import java.util.concurrent.ExecutionException;
 import org.gaul.modernizer_maven_annotations.SuppressModernizer;
 
 /**
- * Utility exception mapper which translates an Exception to a specified type of
- * Exception.
- *
- * <p>
- * This mapper is intended to be used with
- * {@link com.google.common.util.concurrent.Futures#makeChecked(
- * com.google.common.util.concurrent.ListenableFuture, Function)}
+ * Utility exception mapper which translates an Exception to a specified type of Exception. This mapper is intended to
+ * be primarily used with {@code com.google.common.util.concurrent.Futures.makeChecked()}
  * <ul>
- * <li>if exception is the specified type or one of its subclasses, it returns
- * original exception.
- * <li>if exception is {@link ExecutionException} and the cause is of the
- * specified type, it returns the cause
- * <li>otherwise returns an instance of the specified exception type with
- * original exception as the cause.
+ *   <li>if exception is the specified type or one of its subclasses, it returns original exception.
+ *   <li>if exception is {@link ExecutionException} and the cause is of the specified type, it returns the cause
+ *   <li>otherwise returns an instance of the specified exception type with original exception as the cause.
  * </ul>
  *
  * @param <X> the exception type

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -10,7 +10,6 @@ package org.opendaylight.yangtools.util.concurrent;
 
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -14,20 +14,28 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
 /**
- * Utility exception mapper which translates an Exception to a specified type of Exception.
+ * Utility exception mapper which translates an Exception to a specified type of
+ * Exception.
  *
- * This mapper is intended to be used with {@link com.google.common.util.concurrent.Futures#makeChecked(com.google.common.util.concurrent.ListenableFuture, Function)}
+ * <p>
+ * This mapper is intended to be used with
+ * {@link com.google.common.util.concurrent.Futures#makeChecked(com.google.common.util.concurrent.ListenableFuture, Function)}
  * <ul>
- * <li>if exception is the specified type or one of its subclasses, it returns original exception.
- * <li>if exception is {@link ExecutionException} and the cause is of the specified type, it returns the cause
- * <li>otherwise returns an instance of the specified exception type with original exception as the cause.
+ * <li>if exception is the specified type or one of its subclasses, it returns
+ * original exception.
+ * <li>if exception is {@link ExecutionException} and the cause is of the
+ * specified type, it returns the cause
+ * <li>otherwise returns an instance of the specified exception type with
+ * original exception as the cause.
  * </ul>
  *
  * @author Thomas Pantelis
  *
- * @param <X> the exception type
+ * @param <X>
+ *            the exception type
  */
 public abstract class ExceptionMapper<X extends Exception> implements Function<Exception, X> {
+
     private final Class<X> exceptionType;
     private final String opName;
 

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -11,6 +11,7 @@ package org.opendaylight.yangtools.util.concurrent;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Function;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
@@ -71,8 +72,9 @@ public abstract class ExceptionMapper<X extends Exception> implements Function<E
      */
     protected abstract X newWithCause(String message, Throwable cause);
 
-    @SuppressWarnings("unchecked")
     @Override
+    @SuppressWarnings("unchecked")
+    @SuppressFBWarnings({"BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE"})
     public X apply(final Exception input) {
 
         // If exception is of the specified type,return it.

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -14,6 +14,7 @@ import com.google.common.base.Function;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
 
 /**
  * Utility exception mapper which translates an Exception to a specified type of
@@ -32,11 +33,10 @@ import java.util.concurrent.ExecutionException;
  * original exception as the cause.
  * </ul>
  *
+ * @param <X> the exception type
  * @author Thomas Pantelis
- *
- * @param <X>
- *            the exception type
  */
+@SuppressModernizer
 public abstract class ExceptionMapper<X extends Exception> implements Function<Exception, X> {
 
     private final Class<X> exceptionType;

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -19,7 +19,8 @@ import java.util.concurrent.ExecutionException;
  *
  * <p>
  * This mapper is intended to be used with
- * {@link com.google.common.util.concurrent.Futures#makeChecked(com.google.common.util.concurrent.ListenableFuture, Function)}
+ * {@link com.google.common.util.concurrent.Futures#makeChecked(
+ * com.google.common.util.concurrent.ListenableFuture, Function)}
  * <ul>
  * <li>if exception is the specified type or one of its subclasses, it returns
  * original exception.
@@ -71,34 +72,34 @@ public abstract class ExceptionMapper<X extends Exception> implements Function<E
 
     @SuppressWarnings("unchecked")
     @Override
-    public X apply(final Exception e) {
+    public X apply(final Exception input) {
 
         // If exception is of the specified type,return it.
-        if (exceptionType.isAssignableFrom( e.getClass())) {
-            return (X) e;
+        if (exceptionType.isAssignableFrom(input.getClass())) {
+            return (X) input;
         }
 
         // If exception is ExecutionException whose cause is of the specified
         // type, return the cause.
-        if (e instanceof ExecutionException && e.getCause() != null) {
-            if (exceptionType.isAssignableFrom(e.getCause().getClass())) {
-                return (X) e.getCause();
+        if (input instanceof ExecutionException && input.getCause() != null) {
+            if (exceptionType.isAssignableFrom(input.getCause().getClass())) {
+                return (X) input.getCause();
             }
-            return newWithCause(opName + " execution failed", e.getCause());
+            return newWithCause(opName + " execution failed", input.getCause());
         }
 
         // Otherwise return an instance of the specified type with the original
         // cause.
 
-        if (e instanceof InterruptedException) {
-            return newWithCause(opName + " was interupted.", e);
+        if (input instanceof InterruptedException) {
+            return newWithCause(opName + " was interupted.", input);
         }
 
-        if (e instanceof CancellationException ) {
-            return newWithCause(opName + " was cancelled.", e);
+        if (input instanceof CancellationException) {
+            return newWithCause(opName + " was cancelled.", input);
         }
 
         // We really shouldn't get here but need to cover it anyway for completeness.
-        return newWithCause(opName + " encountered an unexpected failure", e);
+        return newWithCause(opName + " encountered an unexpected failure", input);
     }
 }

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -44,6 +44,15 @@ public abstract class ExceptionMapper<X extends Exception> implements Function<E
     }
 
     /**
+     * Return the exception class produced by this instance.
+     *
+     * @return Exception class.
+     */
+    protected final Class<X> getExceptionType() {
+        return exceptionType;
+    }
+
+    /**
      * Invoked to create a new exception instance of the specified type.
      *
      * @param message the message for the new exception.

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -10,7 +10,6 @@ package org.opendaylight.yangtools.util.concurrent;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Function;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import org.gaul.modernizer_maven_annotations.SuppressModernizer;
@@ -64,7 +63,6 @@ public abstract class ExceptionMapper<X extends Exception> implements Function<E
     protected abstract X newWithCause(String message, Throwable cause);
 
     @Override
-    @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
     public X apply(final Exception input) {
 
         // If exception is of the specified type,return it.

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ExceptionMapper.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2014 Brocade Communications Systems, Inc. and others.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.opendaylight.yangtools.util.concurrent;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Utility exception mapper which translates an Exception to a specified type of Exception.
+ *
+ * This mapper is intended to be used with {@link com.google.common.util.concurrent.Futures#makeChecked(com.google.common.util.concurrent.ListenableFuture, Function)}
+ * <ul>
+ * <li>if exception is the specified type or one of its subclasses, it returns original exception.
+ * <li>if exception is {@link ExecutionException} and the cause is of the specified type, it returns the cause
+ * <li>otherwise returns an instance of the specified exception type with original exception as the cause.
+ * </ul>
+ *
+ * @author Thomas Pantelis
+ *
+ * @param <X> the exception type
+ */
+public abstract class ExceptionMapper<X extends Exception> implements Function<Exception, X> {
+    private final Class<X> exceptionType;
+    private final String opName;
+
+    /**
+     * Constructor.
+     *
+     * @param opName the String prefix for exception messages.
+     * @param exceptionType the exception type to which to translate.
+     */
+    public ExceptionMapper(final String opName, final Class<X> exceptionType) {
+        this.exceptionType = Preconditions.checkNotNull(exceptionType);
+        this.opName = Preconditions.checkNotNull(opName);
+    }
+
+    /**
+     * Invoked to create a new exception instance of the specified type.
+     *
+     * @param message the message for the new exception.
+     * @param cause the cause for the new exception.
+     *
+     * @return an instance of the exception type.
+     */
+    protected abstract X newWithCause(String message, Throwable cause);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public X apply(final Exception e) {
+
+        // If exception is of the specified type,return it.
+        if (exceptionType.isAssignableFrom( e.getClass())) {
+            return (X) e;
+        }
+
+        // If exception is ExecutionException whose cause is of the specified
+        // type, return the cause.
+        if (e instanceof ExecutionException && e.getCause() != null) {
+            if (exceptionType.isAssignableFrom( e.getCause().getClass())) {
+                return (X) e.getCause();
+            } else {
+                return newWithCause(opName + " execution failed", e.getCause());
+            }
+        }
+
+        // Otherwise return an instance of the specified type with the original
+        // cause.
+
+        if (e instanceof InterruptedException) {
+            return newWithCause( opName + " was interupted.", e);
+        }
+
+        if (e instanceof CancellationException ) {
+            return newWithCause( opName + " was cancelled.", e);
+        }
+
+        // We really shouldn't get here but need to cover it anyway for completeness.
+        return newWithCause(opName + " encountered an unexpected failure", e);
+    }
+}

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Robert Varga.  All rights reserved.
+ * Copyright (c) 2014 Robert Varga. and others.  All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
@@ -45,7 +45,8 @@ public final class ReflectiveExceptionMapper<X extends Exception> extends Except
      * @throws IllegalArgumentException when the supplied exception class does not pass sanity checks
      * @throws SecurityException when the required constructor is not accessible
      */
-    public static <X extends Exception> ReflectiveExceptionMapper<X> create(final String opName, final Class<X> exceptionType) throws SecurityException {
+    public static <X extends Exception> ReflectiveExceptionMapper<X> create(final String opName,
+            final Class<X> exceptionType) throws SecurityException {
         final Constructor<X> c;
         try {
             c = exceptionType.getConstructor(String.class, Throwable.class);
@@ -55,7 +56,8 @@ public final class ReflectiveExceptionMapper<X extends Exception> extends Except
 
         try {
             c.newInstance(opName, new Throwable());
-        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+                | InvocationTargetException e) {
             throw new IllegalArgumentException("Constructor " + c.getName() + " failed to pass instantiation test", e);
         }
 

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
@@ -29,7 +29,8 @@ public final class ReflectiveExceptionMapper<X extends Exception> extends Except
     protected X newWithCause(final String message, final Throwable cause) {
         try {
             return ctor.newInstance(message, cause);
-        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+                | InvocationTargetException e) {
             throw new IllegalStateException("Failed to instantiate exception " + ctor.getDeclaringClass(), e);
         }
     }

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
@@ -47,7 +47,7 @@ public final class ReflectiveExceptionMapper<X extends Exception> extends Except
      * @throws SecurityException when the required constructor is not accessible
      */
     public static <X extends Exception> ReflectiveExceptionMapper<X> create(final String opName,
-            final Class<X> exceptionType) throws SecurityException {
+            final Class<X> exceptionType) {
         final Constructor<X> c;
         try {
             c = exceptionType.getConstructor(String.class, Throwable.class);

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2014 Robert Varga.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.opendaylight.yangtools.util.concurrent;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Convenience {@link ExceptionMapper} which instantiates specified Exception using
+ * reflection. The Exception types are expected to declare an accessible constructor
+ * which takes two arguments: a String and a Throwable.
+ *
+ * @param <X> Exception type
+ */
+public final class ReflectiveExceptionMapper<X extends Exception> extends ExceptionMapper<X> {
+    private final Constructor<X> ctor;
+
+    private ReflectiveExceptionMapper(final String opName, final Constructor<X> ctor) {
+        super(opName, ctor.getDeclaringClass());
+        this.ctor = ctor;
+    }
+
+    @Override
+    protected X newWithCause(final String message, final Throwable cause) {
+        try {
+            return ctor.newInstance(message, cause);
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            throw new IllegalStateException("Failed to instantiate exception " + ctor.getDeclaringClass(), e);
+        }
+    }
+
+    /**
+     * Create a new instance of the reflective exception mapper. This method performs basic
+     * sanity checking on the exception class. This method is potentially very costly, so
+     * users are strongly encouraged to cache the returned mapper for reuse.
+     *
+     * @param opName Operation performed
+     * @param exceptionType Exception type
+     * @return A new mapper instance
+     * @throws IllegalArgumentException when the supplied exception class does not pass sanity checks
+     * @throws SecurityException when the required constructor is not accessible
+     */
+    public static <X extends Exception> ReflectiveExceptionMapper<X> create(final String opName, final Class<X> exceptionType) throws SecurityException {
+        final Constructor<X> c;
+        try {
+            c = exceptionType.getConstructor(String.class, Throwable.class);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException("Class does not define a String, Throwable constructor", e);
+        }
+
+        try {
+            c.newInstance(opName, new Throwable());
+        } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            throw new IllegalArgumentException("Constructor " + c.getName() + " failed to pass instantiation test", e);
+        }
+
+        return new ReflectiveExceptionMapper<>(opName, c);
+    }
+}

--- a/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
+++ b/common/util/src/main/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapper.java
@@ -16,7 +16,9 @@ import java.lang.reflect.InvocationTargetException;
  * which takes two arguments: a String and a Throwable.
  *
  * @param <X> Exception type
+ * @deprecated This class deprecated without replacement.
  */
+@Deprecated(since = "16.0.0", forRemoval = true)
 public final class ReflectiveExceptionMapper<X extends Exception> extends ExceptionMapper<X> {
     private final Constructor<X> ctor;
 
@@ -25,6 +27,7 @@ public final class ReflectiveExceptionMapper<X extends Exception> extends Except
         this.ctor = ctor;
     }
 
+    @Deprecated(since = "16.0.0", forRemoval = true)
     @Override
     protected X newWithCause(final String message, final Throwable cause) {
         try {
@@ -46,6 +49,7 @@ public final class ReflectiveExceptionMapper<X extends Exception> extends Except
      * @throws IllegalArgumentException when the supplied exception class does not pass sanity checks
      * @throws SecurityException when the required constructor is not accessible
      */
+    @Deprecated(since = "16.0.0", forRemoval = true)
     public static <X extends Exception> ReflectiveExceptionMapper<X> create(final String opName,
             final Class<X> exceptionType) {
         final Constructor<X> c;

--- a/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
+++ b/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
@@ -8,6 +8,7 @@
 package org.opendaylight.yangtools.util.concurrent;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.concurrent.ExecutionException;
 import org.junit.Test;
@@ -45,19 +46,22 @@ public class ReflectiveExceptionMapperTest {
     }
 
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoArgumentsContructor() {
-        ReflectiveExceptionMapper.create("no arguments", NoArgumentCtorException.class);
+        assertThrows(IllegalArgumentException.class,
+            () -> ReflectiveExceptionMapper.create("no arguments", NoArgumentCtorException.class));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testPrivateContructor() {
-        ReflectiveExceptionMapper.create("private constructor", PrivateCtorException.class);
+        assertThrows(IllegalArgumentException.class,
+            () -> ReflectiveExceptionMapper.create("private constructor", PrivateCtorException.class));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFailingContructor() {
-        ReflectiveExceptionMapper.create("failing constructor", FailingCtorException.class);
+        assertThrows(IllegalArgumentException.class,
+            () -> ReflectiveExceptionMapper.create("failing constructor", FailingCtorException.class));
     }
 
     @Test

--- a/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
+++ b/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
@@ -10,11 +10,13 @@ package org.opendaylight.yangtools.util.concurrent;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import java.io.Serial;
 import java.util.concurrent.ExecutionException;
 import org.junit.Test;
 
 public class ReflectiveExceptionMapperTest {
     static final class NoArgumentCtorException extends Exception {
+        @Serial
         private static final long serialVersionUID = 1L;
 
         NoArgumentCtorException() {
@@ -22,6 +24,7 @@ public class ReflectiveExceptionMapperTest {
     }
 
     static final class PrivateCtorException extends Exception {
+        @Serial
         private static final long serialVersionUID = 1L;
 
         private PrivateCtorException(final String message, final Throwable cause) {
@@ -30,6 +33,7 @@ public class ReflectiveExceptionMapperTest {
     }
 
     static final class FailingCtorException extends Exception {
+        @Serial
         private static final long serialVersionUID = 1L;
 
         FailingCtorException(final String message, final Throwable cause) {
@@ -38,6 +42,7 @@ public class ReflectiveExceptionMapperTest {
     }
 
     public static final class GoodException extends Exception {
+        @Serial
         private static final long serialVersionUID = 1L;
 
         public GoodException(final String message, final Throwable cause) {

--- a/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
+++ b/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
@@ -7,24 +7,24 @@
  */
 package org.opendaylight.yangtools.util.concurrent;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.Serial;
 import java.util.concurrent.ExecutionException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReflectiveExceptionMapperTest {
-    static final class NoArgumentCtorException extends Exception {
-        @Serial
+    public static final class NoArgumentCtorException extends Exception {
+        @java.io.Serial
         private static final long serialVersionUID = 1L;
 
-        NoArgumentCtorException() {
+        public NoArgumentCtorException() {
+            // Noop
         }
     }
 
-    static final class PrivateCtorException extends Exception {
-        @Serial
+    public static final class PrivateCtorException extends Exception {
+        @java.io.Serial
         private static final long serialVersionUID = 1L;
 
         private PrivateCtorException(final String message, final Throwable cause) {
@@ -32,17 +32,17 @@ public class ReflectiveExceptionMapperTest {
         }
     }
 
-    static final class FailingCtorException extends Exception {
-        @Serial
+    public static final class FailingCtorException extends Exception {
+        @java.io.Serial
         private static final long serialVersionUID = 1L;
 
-        FailingCtorException(final String message, final Throwable cause) {
+        public FailingCtorException(final String message, final Throwable cause) {
             throw new IllegalArgumentException("just for test");
         }
     }
 
     public static final class GoodException extends Exception {
-        @Serial
+        @java.io.Serial
         private static final long serialVersionUID = 1L;
 
         public GoodException(final String message, final Throwable cause) {
@@ -52,31 +52,28 @@ public class ReflectiveExceptionMapperTest {
 
 
     @Test
-    public void testNoArgumentsContructor() {
+    void testNoArgumentsContructor() {
         assertThrows(IllegalArgumentException.class,
             () -> ReflectiveExceptionMapper.create("no arguments", NoArgumentCtorException.class));
     }
 
     @Test
-    public void testPrivateContructor() {
+    void testPrivateContructor() {
         assertThrows(IllegalArgumentException.class,
             () -> ReflectiveExceptionMapper.create("private constructor", PrivateCtorException.class));
     }
 
     @Test
-    public void testFailingContructor() {
+    void testFailingContructor() {
         assertThrows(IllegalArgumentException.class,
             () -> ReflectiveExceptionMapper.create("failing constructor", FailingCtorException.class));
     }
 
     @Test
-    public void testInstantiation() {
-        ReflectiveExceptionMapper<GoodException> mapper = ReflectiveExceptionMapper.create("instantiation",
-            GoodException.class);
-
-        final Throwable cause = new Throwable("some test message");
-
-        GoodException ret = mapper.apply(new ExecutionException("test", cause));
+    void testInstantiation() {
+        final var mapper = ReflectiveExceptionMapper.create("instantiation", GoodException.class);
+        final var cause = new Throwable("some test message");
+        final var ret = mapper.apply(new ExecutionException("test", cause));
 
         assertEquals("instantiation execution failed", ret.getMessage());
         assertEquals(cause, ret.getCause());

--- a/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
+++ b/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
@@ -10,7 +10,6 @@ package org.opendaylight.yangtools.util.concurrent;
 import static org.junit.Assert.assertEquals;
 
 import java.util.concurrent.ExecutionException;
-
 import org.junit.Test;
 
 public final class ReflectiveExceptionMapperTest {

--- a/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
+++ b/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
@@ -12,11 +12,11 @@ import static org.junit.Assert.assertEquals;
 import java.util.concurrent.ExecutionException;
 import org.junit.Test;
 
-public final class ReflectiveExceptionMapperTest {
+public class ReflectiveExceptionMapperTest {
     static final class NoArgumentCtorException extends Exception {
         private static final long serialVersionUID = 1L;
 
-        public NoArgumentCtorException() {
+        NoArgumentCtorException() {
             super();
         }
     }
@@ -32,12 +32,12 @@ public final class ReflectiveExceptionMapperTest {
     static final class FailingCtorException extends Exception {
         private static final long serialVersionUID = 1L;
 
-        public FailingCtorException(final String message, final Throwable cause) {
+        FailingCtorException(final String message, final Throwable cause) {
             throw new IllegalArgumentException("just for test");
         }
     }
 
-    static final class GoodException extends Exception {
+    public static final class GoodException extends Exception {
         private static final long serialVersionUID = 1L;
 
         public GoodException(final String message, final Throwable cause) {
@@ -46,24 +46,25 @@ public final class ReflectiveExceptionMapperTest {
     }
 
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testNoArgumentsContructor() {
         ReflectiveExceptionMapper.create("no arguments", NoArgumentCtorException.class);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testPrivateContructor() {
         ReflectiveExceptionMapper.create("private constructor", PrivateCtorException.class);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testFailingContructor() {
         ReflectiveExceptionMapper.create("failing constructor", FailingCtorException.class);
     }
 
     @Test
     public void testInstantiation() {
-        ReflectiveExceptionMapper<GoodException> mapper = ReflectiveExceptionMapper.create("instantiation", GoodException.class);
+        ReflectiveExceptionMapper<GoodException> mapper = ReflectiveExceptionMapper.create("instantiation",
+            GoodException.class);
 
         final Throwable cause = new Throwable("some test message");
 

--- a/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
+++ b/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
@@ -17,7 +17,6 @@ public class ReflectiveExceptionMapperTest {
         private static final long serialVersionUID = 1L;
 
         NoArgumentCtorException() {
-            super();
         }
     }
 

--- a/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
+++ b/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2014 Robert Varga.  All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.opendaylight.yangtools.util.concurrent;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Test;
+
+public final class ReflectiveExceptionMapperTest {
+    static final class NoArgumentCtorException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public NoArgumentCtorException() {
+            super();
+        }
+    }
+
+    static final class PrivateCtorException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        private PrivateCtorException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    static final class FailingCtorException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public FailingCtorException(final String message, final Throwable cause) {
+            throw new IllegalArgumentException("just for test");
+        }
+    }
+
+    static final class GoodException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public GoodException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testNoArgumentsContructor() {
+        ReflectiveExceptionMapper.create("no arguments", NoArgumentCtorException.class);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testPrivateContructor() {
+        ReflectiveExceptionMapper.create("private constructor", PrivateCtorException.class);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testFailingContructor() {
+        ReflectiveExceptionMapper.create("failing constructor", FailingCtorException.class);
+    }
+
+    @Test
+    public void testInstantiation() {
+        ReflectiveExceptionMapper<GoodException> mapper = ReflectiveExceptionMapper.create("instantiation", GoodException.class);
+
+        final Throwable cause = new Throwable("some test message");
+
+        GoodException ret = mapper.apply(new ExecutionException("test", cause));
+
+        assertEquals("instantiation execution failed", ret.getMessage());
+        assertEquals(cause, ret.getCause());
+    }
+}

--- a/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
+++ b/common/util/src/test/java/org/opendaylight/yangtools/util/concurrent/ReflectiveExceptionMapperTest.java
@@ -13,7 +13,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 
+@Deprecated(since = "16.0.0", forRemoval = true)
 public class ReflectiveExceptionMapperTest {
+    @Deprecated(since = "16.0.0", forRemoval = true)
     public static final class NoArgumentCtorException extends Exception {
         @java.io.Serial
         private static final long serialVersionUID = 1L;
@@ -23,6 +25,7 @@ public class ReflectiveExceptionMapperTest {
         }
     }
 
+    @Deprecated(since = "16.0.0", forRemoval = true)
     public static final class PrivateCtorException extends Exception {
         @java.io.Serial
         private static final long serialVersionUID = 1L;
@@ -32,6 +35,7 @@ public class ReflectiveExceptionMapperTest {
         }
     }
 
+    @Deprecated(since = "16.0.0", forRemoval = true)
     public static final class FailingCtorException extends Exception {
         @java.io.Serial
         private static final long serialVersionUID = 1L;
@@ -41,6 +45,7 @@ public class ReflectiveExceptionMapperTest {
         }
     }
 
+    @Deprecated(since = "16.0.0", forRemoval = true)
     public static final class GoodException extends Exception {
         @java.io.Serial
         private static final long serialVersionUID = 1L;
@@ -51,24 +56,28 @@ public class ReflectiveExceptionMapperTest {
     }
 
 
+    @Deprecated(since = "16.0.0", forRemoval = true)
     @Test
     void testNoArgumentsContructor() {
         assertThrows(IllegalArgumentException.class,
             () -> ReflectiveExceptionMapper.create("no arguments", NoArgumentCtorException.class));
     }
 
+    @Deprecated(since = "16.0.0", forRemoval = true)
     @Test
     void testPrivateContructor() {
         assertThrows(IllegalArgumentException.class,
             () -> ReflectiveExceptionMapper.create("private constructor", PrivateCtorException.class));
     }
 
+    @Deprecated(since = "16.0.0", forRemoval = true)
     @Test
     void testFailingContructor() {
         assertThrows(IllegalArgumentException.class,
             () -> ReflectiveExceptionMapper.create("failing constructor", FailingCtorException.class));
     }
 
+    @Deprecated(since = "16.0.0", forRemoval = true)
     @Test
     void testInstantiation() {
         final var mapper = ReflectiveExceptionMapper.create("instantiation", GoodException.class);


### PR DESCRIPTION
- **Initial empty repository**
- **Bug 1392: New yang-common/util classes**
- **BUG-1469: introduce ReflectiveExceptionMapper**
- **Fix license header violations in common/util**
- **Organize Imports to be Checkstyle compliant in utils**
- **Checkstyle clean up about 200 trivial violation**
- **Address trivial eclipse warnings**
- **Fix eclipse/checkstyle warnings**
- **Remove explicit default super-constructor calls**
- **Cleanup use of Guava library**
- **Fix FindBugs violations and enable enforcement in utils**
- **Do not declare runtime exceptions**
- **Add @SuppressModernizer**
- **Update ExceptionMapper documentation**
- **Use assertThrows() in common-util**
- **Use @Serial in util**
- **Clean up ExceptionMapper**
- **Migrate common/util to JUnit5**
- **Remove more unused @SuppressFBWarnings**
- **Remove an unused SpotBugs suppression**
- **Modernize ExceptionMapper**
- **Deprecate ReflectiveExceptionMapper**
